### PR TITLE
TL-Report-correction-PI-3988 and PI 5239

### DIFF
--- a/configs/reports/configs/tl-reports.yml
+++ b/configs/reports/configs/tl-reports.yml
@@ -155,7 +155,7 @@ ReportDefinitions:
       SELECT tradelicensedetailid,array_to_string(array_agg(message.message),',') AS acc FROM eg_tl_accessory
       LEFT OUTER JOIN message ON code=CONCAT('TRADELICENSE_ACCESSORIESCATEGORY_', REGEXP_REPLACE(accessorycategory, '[^A-Za-z0-9]','_', 'g')) AND message.locale = 'en_IN' GROUP BY 1 ) tlacc ON tlacc.tradelicensedetailid = tld.id
     Join eg_user ON eg_user.id = receipt.createdby::INTEGER
-    WHERE tl.Status in ('APPROVED', 'PAID', 'CANCELLED') AND tl.tenantId LIKE $tenantid
+    WHERE  tl.tenantId = $tenantid
 
 
 - reportName: StateTradeLicenseCancelledRegistryReport


### PR DESCRIPTION
The issue may have been for the records before the TL workflow change when the payments were being received before processing the application. some changes are imposed in report to focus on the receipts only rather than the status of applications